### PR TITLE
Implementação inicial de CRUD de tarefas

### DIFF
--- a/sistema-tarefas/src/main/java/com/exemplo/sistema/controller/TaskController.java
+++ b/sistema-tarefas/src/main/java/com/exemplo/sistema/controller/TaskController.java
@@ -1,0 +1,54 @@
+package com.exemplo.sistema.controller;
+
+import com.exemplo.sistema.model.Task;
+import com.exemplo.sistema.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+    private final TaskService service;
+
+    public TaskController(TaskService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<Task> list() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Task> get(@PathVariable Long id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Task> create(@Validated @RequestBody Task task) {
+        Task created = service.save(task);
+        return ResponseEntity.created(URI.create("/api/tasks/" + created.getId())).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Task> update(@PathVariable Long id, @Validated @RequestBody Task task) {
+        return service.findById(id)
+                .map(existing -> {
+                    task.setId(existing.getId());
+                    return ResponseEntity.ok(service.save(task));
+                })
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/sistema-tarefas/src/main/java/com/exemplo/sistema/model/Task.java
+++ b/sistema-tarefas/src/main/java/com/exemplo/sistema/model/Task.java
@@ -1,0 +1,73 @@
+package com.exemplo.sistema.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "tasks")
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String title;
+    private String description;
+    private LocalDate dueDate;
+    private boolean completed;
+
+    public Task() {
+    }
+
+    public Task(String title, String description, LocalDate dueDate, boolean completed) {
+        this.title = title;
+        this.description = description;
+        this.dueDate = dueDate;
+        this.completed = completed;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+}

--- a/sistema-tarefas/src/main/java/com/exemplo/sistema/repository/TaskRepository.java
+++ b/sistema-tarefas/src/main/java/com/exemplo/sistema/repository/TaskRepository.java
@@ -1,0 +1,7 @@
+package com.exemplo.sistema.repository;
+
+import com.exemplo.sistema.model.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/sistema-tarefas/src/main/java/com/exemplo/sistema/service/TaskService.java
+++ b/sistema-tarefas/src/main/java/com/exemplo/sistema/service/TaskService.java
@@ -1,0 +1,33 @@
+package com.exemplo.sistema.service;
+
+import com.exemplo.sistema.model.Task;
+import com.exemplo.sistema.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TaskService {
+    private final TaskRepository repository;
+
+    public TaskService(TaskRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<Task> findAll() {
+        return repository.findAll();
+    }
+
+    public Optional<Task> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    public Task save(Task task) {
+        return repository.save(task);
+    }
+
+    public void deleteById(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/sistema-tarefas/src/main/resources/application.properties
+++ b/sistema-tarefas/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=sistema-tarefas
+spring.datasource.url=jdbc:h2:mem:tarefas;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true


### PR DESCRIPTION
## Resumo
- adicionar entidade `Task` com atributos básicos
- criar repositório JPA, serviço e controlador REST para tarefas
- configurar `application.properties` para usar banco H2 em memória

## Testes
- `mvn test` *(falhou: `mvn` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686709423064832ea7b2a47ed8433a69