### PR TITLE
Add basic tests and documentation

### DIFF
--- a/docs/6-testes-validacao/README.md
+++ b/docs/6-testes-validacao/README.md
@@ -33,3 +33,13 @@ Esta seção contém os recursos necessários para testar e validar a aplicaçã
 - Spring Test
 - JMeter
 - Postman/Insomnia
+
+## Como Executar os Testes
+
+Dentro do diretório `sistema-tarefas` utilize o Maven para rodar todos os testes automatizados:
+
+```bash
+mvn test
+```
+
+Os testes incluem verificações de integração para os principais endpoints da aplicação.

--- a/sistema-tarefas/README.md
+++ b/sistema-tarefas/README.md
@@ -10,3 +10,9 @@ mvn spring-boot:run
 
 A aplicação possui endpoints REST para gerenciamento de usuários, tarefas e projetos.
 As dependências estão definidas no `pom.xml` fornecido na documentação.
+
+Para executar os testes automatizados:
+
+```bash
+mvn test
+```

--- a/sistema-tarefas/pom.xml
+++ b/sistema-tarefas/pom.xml
@@ -79,6 +79,13 @@
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash-logback-encoder.version}</version>
         </dependency>
+
+        <!-- Dependências de Teste -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         
 
         

--- a/sistema-tarefas/src/test/java/com/exemplo/sistema/ApplicationTests.java
+++ b/sistema-tarefas/src/test/java/com/exemplo/sistema/ApplicationTests.java
@@ -1,0 +1,12 @@
+package com.exemplo.sistema;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/sistema-tarefas/src/test/java/com/exemplo/sistema/TaskControllerTest.java
+++ b/sistema-tarefas/src/test/java/com/exemplo/sistema/TaskControllerTest.java
@@ -1,0 +1,51 @@
+package com.exemplo.sistema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TaskControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createAndListTask() throws Exception {
+        // lista inicialmente vazia
+        mockMvc.perform(get("/api/tasks"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("title", "Teste");
+        payload.put("description", "Descricao");
+        payload.put("dueDate", LocalDate.now().toString());
+        payload.put("completed", false);
+
+        mockMvc.perform(post("/api/tasks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/tasks"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Teste"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Maven test dependency
- create integration tests for TaskController
- add basic context load test
- document running the tests in docs and README

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68671fe45c7c832e94e71e8cfd38a7c1